### PR TITLE
Support format parameter

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/redpen-cli-*/** linguist-vendored

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require 'redpen_ruby'
 config_file = './lib/redpen-cli-1.1/conf/redpen-conf-en.xml'
 target_file = './lib/redpen-cli-1.1/sample-doc/en/sampledoc-en.md'
 
-redpen = RedpenRuby.check(config_file, target_file)
+redpen = RedpenRuby.check(config_file, target_file, format: 'markdown')
 
 if redpen.valid?
   puts 'Ok, Valid!'

--- a/lib/redpen_ruby.rb
+++ b/lib/redpen_ruby.rb
@@ -3,8 +3,8 @@ require 'redpen_ruby/process'
 require 'redpen_ruby/format_message'
 
 module RedpenRuby
-  def self.check(config, target)
+  def self.check(config, target, format: "plain")
     validation = Process.new
-    validation.redpen_ruby(config, target)
+    validation.redpen_ruby(config, target, format)
   end
 end

--- a/lib/redpen_ruby/process.rb
+++ b/lib/redpen_ruby/process.rb
@@ -1,8 +1,8 @@
 module RedpenRuby
   class Process
-    def redpen_ruby(config, target)
+    def redpen_ruby(config, target, format)
       redpen_bin = File.expand_path(File.dirname(__FILE__) + '/../redpen-cli-1.1/bin/redpen')
-      format_redpen_ruby_output(`#{redpen_bin} -c #{config} #{target} 2>&1`, `#{redpen_bin} -v`)
+      format_redpen_ruby_output(`#{redpen_bin} -c #{config} -f #{format} #{target} 2>&1`, `#{redpen_bin} -v`)
     end
 
     def format_redpen_ruby_output(message, version)


### PR DESCRIPTION
# WHAT

Add format parameter to make redpen_ruby possible to lint markdown documents.
# WHY

Because redpen_ruby does not specify [input_format](http://redpen.cc/docs/latest/index.html#command-line-tool) parameter, redpen-cli always consider the document as written in plain text format.

In addition, I added .gitattributes to mark lib/redpen-cli-\* directory as [vendored directory](https://github.com/github/linguist#using-gitattributes), since it contains vendor files, to allow GitHub to parse language stats correctly. :)
## BEFORE

![image](https://cloud.githubusercontent.com/assets/96157/14776953/ca3abca6-0b04-11e6-880b-31d30c09a1d3.png)
## AFTER

![image](https://cloud.githubusercontent.com/assets/96157/14777011/1d514d92-0b05-11e6-971f-22d8db8f7d62.png)
